### PR TITLE
[Feature] Adding two level inverter description to the MAS model.

### DIFF
--- a/schemas/inputs.json
+++ b/schemas/inputs.json
@@ -23,15 +23,18 @@
             "title": "converterInformation",
             "type": "object",
             "properties": {
-                "supportedTopologies":{
+                "supportedTopologies": {
                     "type": "object",
                     "properties": {
                         "flyback": {
-                            "$ref": "/schemas/inputs/topologies/flyback.json",
+                            "$ref": "/schemas/inputs/topologies/flyback.json"
+                        },
+                        "inverter": {
+                            "$ref": "/schemas/inputs/topologies/inverter.json"
                         }
                     }
                 }
-            },
+            }
         }
     },
     "required": ["operatingPoints", "designRequirements"],

--- a/schemas/inputs.json
+++ b/schemas/inputs.json
@@ -30,7 +30,7 @@
                             "$ref": "/schemas/inputs/topologies/flyback.json"
                         },
                         "inverter": {
-                            "$ref": "/schemas/inputs/topologies/inverter.json"
+                            "$ref": "/schemas/inputs/topologies/twoLevelInverter.json"
                         }
                     }
                 }

--- a/schemas/inputs/topologies/inverter.json
+++ b/schemas/inputs/topologies/inverter.json
@@ -109,6 +109,22 @@
                 "inductance": {
                     "description": "Load inductance",
                     "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                },
+                "phaseVoltage": {
+                    "description": "Grid phase voltage",
+                    "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                },
+                "gridFrequency": {
+                    "description": "Grid frequency",
+                    "type": "number"
+                },
+                "gridResistance": {
+                    "description": "Equivalent grid resistance",
+                    "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                },
+                "gridInductance": {
+                    "description": "Equivalent grid inductance",
+                    "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
                 }
             },
             "required": ["type"],
@@ -119,6 +135,14 @@
                     },
                     "then": {
                         "required": ["resistance", "inductance"]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {"type": {"const": "grid"}}
+                    },
+                    "then": {
+                        "required": ["phaseVoltage", "gridFrequency", "gridResistance", "gridInductance"]
                     }
                 }
             ]
@@ -140,6 +164,10 @@
                     "description": "Current phase angle in degrees",
                     "type": "number"
                 },
+                "outputPower": {
+                    "description": "Output power at the operating point",
+                    "type": "number"
+                },
                 "load": {
                     "description": "Load connected to the inverter",
                     "$ref": "#/$defs/inverterLoad"
@@ -149,6 +177,20 @@
             "anyOf": [
                 {"required": ["powerFactor"]},
                 {"required": ["currentPhaseAngle"]}
+            ],
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "load": {
+                                "properties": {"type": {"const": "grid"}}
+                            }
+                        }
+                    },
+                    "then": {
+                        "required": ["outputPower"]
+                    }
+                }
             ]
         },
         "inverterDownstreamFilter": {

--- a/schemas/inputs/topologies/inverter.json
+++ b/schemas/inputs/topologies/inverter.json
@@ -1,0 +1,188 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "http://openmagnetics.com/schemas/inputs/topologies/inverter.json",
+    "title": "inverter",
+    "description": "The description of a two level inverter leg excitation",
+    "type": "object",
+    "properties": {
+        "dcBusVoltage": {
+            "description": "The DC bus voltage",
+            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+        },
+        "vdcRipple": {
+            "description": "The ripple of the DC bus voltage",
+            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+        },
+        "inverterLegPowerRating": {
+            "description": "The power rating of the inverter leg",
+            "type": "number"
+        },
+        "lineRmsCurrent": {
+            "description": "The RMS current of the line",
+            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+        },
+        "downstreamFilter": {
+            "description": "Downstream filter elements if present",
+            "$ref": "#/$defs/inverterDownstreamFilter"
+        },
+        "switchingFrequency": {
+            "description": "Switching frequency",
+            "type": "number"
+        },
+        "riseTime": {
+            "description": "Rise time of the transistors",
+            "type": "number"
+        },
+        "deadtime": {
+            "description": "Deadtime duration",
+            "type": "number"
+        },
+        "pwmType": {
+            "description": "Waveform used to generate PWM",
+            "$ref": "#/$defs/pwmType"
+        },
+        "modulationStrategy": {
+            "description": "Modulation strategy",
+            "$ref": "#/$defs/modulationStrategy"
+        },
+        "thirdHarmonicInjectionCoefficient": {
+            "description": "Coefficient for third harmonic injection",
+            "type": "number"
+        },
+        "modulationDepth": {
+            "description": "Modulation depth",
+            "type": "number"
+        },
+        "operatingPoints": {
+            "description": "A list of operating points",
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/inverterOperatingPoint"
+            },
+            "minItems": 1
+        }
+    },
+    "required": [
+        "dcBusVoltage",
+        "vdcRipple",
+        "inverterLegPowerRating",
+        "lineRmsCurrent",
+        "switchingFrequency",
+        "riseTime",
+        "deadtime",
+        "pwmType",
+        "modulationStrategy",
+        "modulationDepth",
+        "operatingPoints"
+    ],
+    "$defs": {
+        "pwmType": {
+            "description": "Type of PWM carrier waveform",
+            "title": "pwmType",
+            "type": "string",
+            "enum": ["sawtooth", "triangular"]
+        },
+        "modulationStrategy": {
+            "description": "Strategy used for modulation",
+            "title": "modulationStrategy",
+            "type": "string",
+            "enum": ["SPWM", "SVPWM"]
+        },
+        "loadType": {
+            "description": "Type of load",
+            "title": "loadType",
+            "type": "string",
+            "enum": ["grid", "R-L"]
+        },
+        "inverterLoad": {
+            "description": "The load connected to the inverter",
+            "title": "inverterLoad",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "$ref": "#/$defs/loadType"
+                },
+                "resistance": {
+                    "description": "Load resistance",
+                    "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                },
+                "inductance": {
+                    "description": "Load inductance",
+                    "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                }
+            },
+            "required": ["type"],
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"type": {"const": "R-L"}}
+                    },
+                    "then": {
+                        "required": ["resistance", "inductance"]
+                    }
+                }
+            ]
+        },
+        "inverterOperatingPoint": {
+            "description": "The description of one inverter operating point",
+            "title": "inverterOperatingPoint",
+            "type": "object",
+            "properties": {
+                "fundamentalFrequency": {
+                    "description": "Fundamental frequency",
+                    "type": "number"
+                },
+                "powerFactor": {
+                    "description": "Power factor at the operating point",
+                    "type": "number"
+                },
+                "currentPhaseAngle": {
+                    "description": "Current phase angle in degrees",
+                    "type": "number"
+                },
+                "load": {
+                    "description": "Load connected to the inverter",
+                    "$ref": "#/$defs/inverterLoad"
+                }
+            },
+            "required": ["fundamentalFrequency", "load"],
+            "anyOf": [
+                {"required": ["powerFactor"]},
+                {"required": ["currentPhaseAngle"]}
+            ]
+        },
+        "inverterDownstreamFilter": {
+            "description": "Downstream filter elements",
+            "title": "inverterDownstreamFilter",
+            "type": "object",
+            "properties": {
+                "capacitor": {
+                    "description": "Capacitor used for LC or LCL filters",
+                    "type": "object",
+                    "properties": {
+                        "capacitance": {
+                            "description": "Capacitance value",
+                            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                        },
+                        "resistance": {
+                            "description": "Equivalent series resistance",
+                            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                        }
+                    },
+                    "required": ["capacitance"]
+                },
+                "inductor2": {
+                    "description": "Second inductor used for LCL filters",
+                    "type": "object",
+                    "properties": {
+                        "inductance": {
+                            "description": "Inductance value",
+                            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                        }
+                    },
+                    "required": ["inductance"]
+                }
+            }
+        }
+    }
+}

--- a/schemas/inputs/topologies/inverter.json
+++ b/schemas/inputs/topologies/inverter.json
@@ -25,33 +25,9 @@
             "description": "Downstream filter elements if present",
             "$ref": "#/$defs/inverterDownstreamFilter"
         },
-        "switchingFrequency": {
-            "description": "Switching frequency",
-            "type": "number"
-        },
-        "riseTime": {
-            "description": "Rise time of the transistors",
-            "type": "number"
-        },
-        "deadtime": {
-            "description": "Deadtime duration",
-            "type": "number"
-        },
-        "pwmType": {
-            "description": "Waveform used to generate PWM",
-            "$ref": "#/$defs/pwmType"
-        },
-        "modulationStrategy": {
-            "description": "Modulation strategy",
-            "$ref": "#/$defs/modulationStrategy"
-        },
-        "thirdHarmonicInjectionCoefficient": {
-            "description": "Coefficient for third harmonic injection",
-            "type": "number"
-        },
-        "modulationDepth": {
-            "description": "Modulation depth",
-            "type": "number"
+        "modulation": {
+            "description": "All parameters related to switching",
+            "$ref": "#/$defs/modulation"
         },
         "operatingPoints": {
             "description": "A list of operating points",
@@ -64,87 +40,121 @@
     },
     "required": [
         "dcBusVoltage",
-        "vdcRipple",
         "inverterLegPowerRating",
         "lineRmsCurrent",
-        "switchingFrequency",
-        "riseTime",
-        "deadtime",
-        "pwmType",
-        "modulationStrategy",
-        "modulationDepth",
         "operatingPoints"
     ],
     "$defs": {
-        "pwmType": {
-            "description": "Type of PWM carrier waveform",
-            "title": "pwmType",
-            "type": "string",
-            "enum": ["sawtooth", "triangular"]
-        },
-        "modulationStrategy": {
-            "description": "Strategy used for modulation",
-            "title": "modulationStrategy",
-            "type": "string",
-            "enum": ["SPWM", "SVPWM"]
-        },
-        "loadType": {
-            "description": "Type of load",
-            "title": "loadType",
-            "type": "string",
-            "enum": ["grid", "R-L"]
-        },
-        "inverterLoad": {
-            "description": "The load connected to the inverter",
-            "title": "inverterLoad",
+        "inverterDownstreamFilter": {
+            "description": "Downstream filter elements",
+            "title": "inverterDownstreamFilter",
             "type": "object",
             "properties": {
-                "type": {
-                    "$ref": "#/$defs/loadType"
+                "filterTopology": {
+                    "description": "Filter type",
+                    "title": "filterTopologies",
+                    "type": "string",
+                    "enum": ["L", "LC", "LCL"]
                 },
-                "resistance": {
-                    "description": "Load resistance",
-                    "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                "inductor": {
+                    "description": "L1 inductor used for L, LC or LCL filters",
+                    "type": "object",
+                    "properties": {
+                        "desiredInductance": {
+                            "description": "Desired inductance for L1",
+                            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                        },
+                        "resistance": {
+                            "description": "Equivalent series resistance",
+                            "type": "number"
+                        }
+                    },
+                    "required": ["desiredInductance"]
                 },
-                "inductance": {
-                    "description": "Load inductance",
-                    "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                "capacitor": {
+                    "description": "Capacitor used for LC or LCL filters",
+                    "type": "object",
+                    "properties": {
+                        "desiredCapacitance": {
+                            "description": "Capacitance value",
+                            "type": "number"
+                        },
+                        "resistance": {
+                            "description": "Equivalent series resistance",
+                            "type": "number"
+                        }
+                    },
+                    "required": ["desiredCapacitance"]
                 },
-                "phaseVoltage": {
-                    "description": "Grid phase voltage",
-                    "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
-                },
-                "gridFrequency": {
-                    "description": "Grid frequency",
-                    "type": "number"
-                },
-                "gridResistance": {
-                    "description": "Equivalent grid resistance",
-                    "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
-                },
-                "gridInductance": {
-                    "description": "Equivalent grid inductance",
-                    "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                "inductor2": {
+                    "description": "Second inductor used for LCL filters",
+                    "type": "object",
+                    "properties": {
+                        "desiredInductance2": {
+                            "description": "Desired inductance for L2",
+                            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+                        },
+                        "resistance": {
+                            "description": "Equivalent series resistance",
+                            "type": "number"
+                        }
+                    },
+                    "required": ["desiredInductance2"]
                 }
             },
-            "required": ["type"],
+            "required": ["filterTopology", "inductor"],
             "allOf": [
                 {
-                    "if": {
-                        "properties": {"type": {"const": "R-L"}}
-                    },
-                    "then": {
-                        "required": ["resistance", "inductance"]
-                    }
+                    "if": { "properties": { "filterTopology": { "enum": ["LC", "LCL"] } } },
+                    "then": { "required": ["capacitor"] }
                 },
                 {
-                    "if": {
-                        "properties": {"type": {"const": "grid"}}
-                    },
-                    "then": {
-                        "required": ["phaseVoltage", "gridFrequency", "gridResistance", "gridInductance"]
-                    }
+                    "if": { "properties": { "filterTopology": { "const": "LCL" } } },
+                    "then": { "required": ["inductor2"] }
                 }
+            ]
+        },
+        "modulation": {
+            "type" : "object",
+            "properties" : {
+                "switchingFrequency": {
+                    "description": "Switching frequency",
+                    "type": "number"
+                },
+                "pwmType": {
+                    "description": "Type of PWM carrier waveform",
+                    "title": "pwmType",
+                    "type": "string",
+                    "enum": ["sawtooth", "triangular"]
+                },
+                "modulationStrategy": {
+                    "description": "Strategy used for modulation",
+                    "title": "modulationStrategy",
+                    "type": "string",
+                    "enum": ["SPWM", "SVPWM", "THIPWM"]
+                },
+                "riseTime": {
+                    "description": "Rise time of the transistors",
+                    "type": "number"
+                },
+                "deadtime": {
+                    "description": "Deadtime duration",
+                    "type": "number"
+                },
+                "thirdHarmonicInjectionCoefficient": {
+                    "description": "Coefficient for third harmonic injection",
+                    "type": "number"
+                },
+                "modulationDepth": {
+                    "description": "Modulation depth",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "switchingFrequency",
+                "pwmType",
+                "modulationStrategy",
+                "modulationDepth"
             ]
         },
         "inverterOperatingPoint": {
@@ -171,6 +181,10 @@
                 "load": {
                     "description": "Load connected to the inverter",
                     "$ref": "#/$defs/inverterLoad"
+                }, 
+                "operatingTemperature": {
+                    "description": "Operating temperature of the Inverter Filter",
+                    "type": "number"
                 }
             },
             "required": ["fundamentalFrequency", "load"],
@@ -183,7 +197,7 @@
                     "if": {
                         "properties": {
                             "load": {
-                                "properties": {"type": {"const": "grid"}}
+                                "properties": {"loadType": {"const": "grid"}}
                             }
                         }
                     },
@@ -193,38 +207,61 @@
                 }
             ]
         },
-        "inverterDownstreamFilter": {
-            "description": "Downstream filter elements",
-            "title": "inverterDownstreamFilter",
+        "inverterLoad": {
+            "description": "The load connected to the inverter",
+            "title": "inverterLoad",
             "type": "object",
             "properties": {
-                "capacitor": {
-                    "description": "Capacitor used for LC or LCL filters",
-                    "type": "object",
-                    "properties": {
-                        "capacitance": {
-                            "description": "Capacitance value",
-                            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
-                        },
-                        "resistance": {
-                            "description": "Equivalent series resistance",
-                            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
-                        }
-                    },
-                    "required": ["capacitance"]
+                "loadType": {
+                    "description": "Type of load",
+                    "title": "loadType",
+                    "type": "string",
+                    "enum": ["grid", "R-L"]
                 },
-                "inductor2": {
-                    "description": "Second inductor used for LCL filters",
-                    "type": "object",
-                    "properties": {
-                        "inductance": {
-                            "description": "Inductance value",
-                            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
-                        }
-                    },
-                    "required": ["inductance"]
+                "resistance": {
+                    "description": "Load resistance",
+                    "type": "number"
+                },
+                "inductance": {
+                    "description": "Load inductance",
+                    "type": "number"
+                },
+                "phaseVoltage": {
+                    "description": "Grid phase voltage",
+                    "type": "number"
+                },
+                "gridFrequency": {
+                    "description": "Grid frequency",
+                    "type": "number"
+                },
+                "gridResistance": {
+                    "description": "Equivalent grid resistance",
+                    "type": "number"
+                },
+                "gridInductance": {
+                    "description": "Equivalent grid inductance",
+                    "type": "number"
                 }
-            }
+            },
+            "required": ["loadType"],
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"loadType": {"const": "R-L"}}
+                    },
+                    "then": {
+                        "required": ["resistance", "inductance"]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {"loadType": {"const": "grid"}}
+                    },
+                    "then": {
+                        "required": ["phaseVoltage", "gridFrequency", "gridResistance", "gridInductance"]
+                    }
+                }
+            ]
         }
     }
 }

--- a/schemas/inputs/topologies/twoLevelInverter.json
+++ b/schemas/inputs/topologies/twoLevelInverter.json
@@ -1,17 +1,22 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "http://openmagnetics.com/schemas/inputs/topologies/inverter.json",
+    "$id": "http://openmagnetics.com/schemas/inputs/topologies/twoLevelInverter.json",
     "title": "twoLevelInverter",
     "description": "The description of a two level inverter leg excitation",
     "type": "object",
     "properties": {
         "dcBusVoltage": {
-            "description": "The DC bus voltage",
+            "description": "The DC bus voltage in V",
             "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
         },
-        "dcVoltageRipple": {
-            "description": "The ripple of the DC bus voltage",
-            "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
+        "dcBusCapacitor": {
+            "description": "DC bus capacitor model",
+            "$ref": "#/$defs/dcBusCapacitor"
+        },
+        "numberOfLegs": {
+            "description": "Number of inverter legs (one leg = two switches). Examples: 2 = single-phase full bridge, 3 = three-phase.",
+            "type": "integer",
+            "enum": [2, 3]
         },
         "inverterLegPowerRating": {
             "description": "The power rating of the inverter leg",
@@ -40,11 +45,29 @@
     },
     "required": [
         "dcBusVoltage",
+        "dcBusCapacitor",
+        "numberOfLegs",
         "inverterLegPowerRating",
         "lineRmsCurrent",
         "operatingPoints"
     ],
     "$defs": {
+        "dcBusCapacitor": {
+            "description": "DC bus capacitor parameters",
+            "title": "dcBusCapacitor",
+            "type": "object",
+            "properties": {
+                "capacitance": {
+                    "description": "Capacitance value in Farads",
+                    "type": "number"
+                },
+                "resistance": {
+                    "description": "Equivalent series resistance in Ohms",
+                    "type": "number"
+                }
+            },
+            "required": ["capacitance"]
+        },
         "inverterDownstreamFilter": {
             "description": "Downstream filter elements",
             "title": "inverterDownstreamFilter",
@@ -61,11 +84,11 @@
                     "type": "object",
                     "properties": {
                         "desiredInductance": {
-                            "description": "Desired inductance for L1",
+                            "description": "Desired inductance for L1 in Henrys",
                             "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
                         },
                         "resistance": {
-                            "description": "Equivalent series resistance",
+                            "description": "Equivalent series resistance in Ohms",
                             "type": "number"
                         }
                     },
@@ -76,11 +99,11 @@
                     "type": "object",
                     "properties": {
                         "desiredCapacitance": {
-                            "description": "Capacitance value",
+                            "description": "Capacitance value in Farads",
                             "type": "number"
                         },
                         "resistance": {
-                            "description": "Equivalent series resistance",
+                            "description": "Equivalent series resistance in Ohms",
                             "type": "number"
                         }
                     },
@@ -91,11 +114,11 @@
                     "type": "object",
                     "properties": {
                         "desiredInductance2": {
-                            "description": "Desired inductance for L2",
+                            "description": "Desired inductance for L2 in Henrys",
                             "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
                         },
                         "resistance": {
-                            "description": "Equivalent series resistance",
+                            "description": "Equivalent series resistance in Ohms",
                             "type": "number"
                         }
                     },
@@ -135,11 +158,11 @@
                     "enum": ["SPWM", "SVPWM", "THIPWM"]
                 },
                 "riseTime": {
-                    "description": "Rise time of the transistors",
+                    "description": "Rise time of the transistors in s",
                     "type": "number"
                 },
                 "deadtime": {
-                    "description": "Deadtime duration",
+                    "description": "Deadtime duration in s",
                     "type": "number"
                 },
                 "thirdHarmonicInjectionCoefficient": {
@@ -164,7 +187,7 @@
             "type": "object",
             "properties": {
                 "fundamentalFrequency": {
-                    "description": "Fundamental frequency",
+                    "description": "Fundamental frequency in Hz",
                     "type": "number"
                 },
                 "powerFactor": {
@@ -176,7 +199,7 @@
                     "type": "number"
                 },
                 "outputPower": {
-                    "description": "Output power at the operating point",
+                    "description": "Output power at the operating point in W",
                     "type": "number"
                 },
                 "load": {
@@ -184,7 +207,7 @@
                     "$ref": "#/$defs/inverterLoad"
                 }, 
                 "operatingTemperature": {
-                    "description": "Operating temperature of the Inverter Filter",
+                    "description": "Operating temperature of the Inverter Filter in °C",
                     "type": "number"
                 }
             },
@@ -220,27 +243,27 @@
                     "enum": ["grid", "R-L"]
                 },
                 "resistance": {
-                    "description": "Load resistance",
+                    "description": "Load resistance in Ohms",
                     "type": "number"
                 },
                 "inductance": {
-                    "description": "Load inductance",
+                    "description": "Load inductance in Henrys",
                     "type": "number"
                 },
                 "phaseVoltage": {
-                    "description": "Grid phase voltage",
+                    "description": "Grid phase voltage in V_RMS",
                     "type": "number"
                 },
                 "gridFrequency": {
-                    "description": "Grid frequency",
+                    "description": "Grid frequency in Hz",
                     "type": "number"
                 },
                 "gridResistance": {
-                    "description": "Equivalent grid resistance",
+                    "description": "Equivalent grid resistance in Ohms",
                     "type": "number"
                 },
                 "gridInductance": {
-                    "description": "Equivalent grid inductance",
+                    "description": "Equivalent grid inductance in Henrys",
                     "type": "number"
                 }
             },

--- a/schemas/inputs/topologies/twoLevelInverter.json
+++ b/schemas/inputs/topologies/twoLevelInverter.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://openmagnetics.com/schemas/inputs/topologies/inverter.json",
-    "title": "inverter",
+    "title": "twoLevelInverter",
     "description": "The description of a two level inverter leg excitation",
     "type": "object",
     "properties": {
@@ -9,7 +9,7 @@
             "description": "The DC bus voltage",
             "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
         },
-        "vdcRipple": {
+        "dcVoltageRipple": {
             "description": "The ripple of the DC bus voltage",
             "$ref": "/schemas/utils.json#/$defs/dimensionWithTolerance"
         },
@@ -115,10 +115,11 @@
             ]
         },
         "modulation": {
+            "description": "The description of one inverter switching modulation scheme",
             "type" : "object",
             "properties" : {
                 "switchingFrequency": {
-                    "description": "Switching frequency",
+                    "description": "Switching frequency in Hz",
                     "type": "number"
                 },
                 "pwmType": {


### PR DESCRIPTION
A proposal for supporting inverters in OM. 
The goal here is to have a generic representation of a two level inverter and its load. 
From that generic model we can then derive constraints on the filtering elements of the inverter, that will in turn permit to design magnetics.

Having a proper description of: 
- the modulation
- the load
- the filter topology
- and the inverter ratings 

is necessary to fully derive the voltage and current harmonics applied to the magnetic elements. 

The proposed description permits to derive design constraints for L, LC, and LCL filters.