### PR TITLE
MAS-RFC 0010: electrostatic shielding requirement (Draft)

### DIFF
--- a/proposals/0010-shielding-requirement.md
+++ b/proposals/0010-shielding-requirement.md
@@ -25,6 +25,11 @@ MAS today has no way to express them:
 - `functionalDescription` models *windings*. A shield is a conductor but not a
   winding — modeling it as a one-turn winding corrupts `turnsRatios`, demands
   a fake excitation in every operating point, and miscounts isolation sides.
+- Electrically, a winding is a two-terminal element: its `connections` are a
+  start/finish pair and load current flows between them. A shield connects at
+  one end only — the far end is left floating so the shield cannot close a
+  shorted turn around the core — and carries only displacement current to
+  its termination. The winding shape cannot express a single-ended conductor.
 - The coil description already *can represent* the result — `layer.type`
   already includes `shielding` — but nothing upstream of the coil can request
   it, so the only route today is hand-authoring `layersDescription`.

--- a/proposals/0010-shielding-requirement.md
+++ b/proposals/0010-shielding-requirement.md
@@ -1,0 +1,161 @@
+# MAS-RFC 0010 — Electrostatic shielding requirement
+
+- **Status:** Draft
+- **Type:** Additive (target: 1.1.0)
+- **Author:** Grant Pitel ([@gpitel](https://github.com/gpitel))
+- **Created:** 2026-07-17
+
+## Summary
+
+Add an optional `shielding` array to `inputs/designRequirements.json`. Each
+entry declares an electrostatic (Faraday) shield between a pair of windings.
+Shields are a *requirement* consumed at coil materialization time — the engine
+inserts SHIELDING-typed layers at the insulation interfaces of the pair — not
+extra entries in `functionalDescription`.
+
+## Motivation
+
+Electrostatic shields between windings are standard practice for breaking
+inter-winding capacitive coupling: a grounded copper foil between primary and
+secondary diverts common-mode displacement current to ground (McLyman,
+*Transformer and Inductor Design Handbook* 3rd ed., ch. 17 §9; Lee,
+*Electronic Transformers and Circuits*, §83 covers the wound-screen variant).
+MAS today has no way to express them:
+
+- `functionalDescription` models *windings*. A shield is a conductor but not a
+  winding — modeling it as a one-turn winding corrupts `turnsRatios`, demands
+  a fake excitation in every operating point, and miscounts isolation sides.
+- The coil description already *can represent* the result — `layer.type`
+  already includes `shielding` — but nothing upstream of the coil can request
+  it, so the only route today is hand-authoring `layersDescription`.
+
+A requirement-level declaration keeps the electrical model clean and lets the
+engine own placement, sizing, and insulation-stack integration.
+
+## Proposal
+
+Add a `shielding` property to `inputs/designRequirements.json`:
+
+```json
+"shielding": {
+    "description": "List of electrostatic shields that must be placed between windings",
+    "type": "array",
+    "items": {
+        "title": "shieldingRequirement",
+        "type": "object",
+        "properties": {
+            "name": {
+                "description": "A label that identifies this shield",
+                "type": "string"
+            },
+            "type": {
+                "description": "Construction of the shield: a continuous foil (near-complete coverage, must stay much thinner than a skin depth to limit eddy loss), or a screen wound from wire like a winding layer (runs on standard winding equipment, lower eddy loss, partial coverage)",
+                "title": "shieldingType",
+                "type": "string",
+                "enum": ["foil", "wound"],
+                "default": "foil"
+            },
+            "wire": {
+                "description": "Name of the wire the screen is wound from, when the shield type is wound. The shield layer thickness follows the wire outer diameter",
+                "type": "string"
+            },
+            "betweenWindings": {
+                "description": "Names of the two windings between which the shield must be placed, as windings are referenced by name throughout MAS. The shield is inserted at every interface where sections of these two windings are adjacent, unless restricted by interfaces",
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 2,
+                "maxItems": 2
+            },
+            "interfaces": {
+                "description": "Zero-based ordinals of the insulation interfaces of the wound coil (counted in winding order, wrap-around interface last) at which the shield must be placed. If absent, the shield is placed at every interface where the two windings are adjacent",
+                "type": "array",
+                "items": {"type": "integer", "minimum": 0},
+                "minItems": 1,
+                "uniqueItems": true
+            },
+            "material": {
+                "description": "Material of the shield, by default copper",
+                "type": "string",
+                "default": "copper"
+            },
+            "thickness": {
+                "description": "Thickness of the shield, in m",
+                "type": "number",
+                "exclusiveMinimum": 0
+            },
+            "coverage": {
+                "description": "Proportion of the winding window breadth covered by the shield, from 0 to 1. Ignored when margin is present",
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "maximum": 1,
+                "default": 1
+            },
+            "margin": {
+                "description": "Distances at the extremes of the winding window kept clear by the shield, in m. Two-element array, from 'inner or top' to 'outer or bottom', like section margins. Takes precedence over coverage",
+                "type": "array",
+                "items": {"type": "number", "minimum": 0},
+                "minItems": 2,
+                "maxItems": 2
+            },
+            "connection": {
+                "description": "How the shield termination is connected. A shield terminates at one point only — the other end is left unconnected to avoid a shorted turn — so unlike windings there is a single connection instead of a start-finish pair",
+                "$ref": "../magnetic/coil.json#/$defs/connection"
+            },
+            "terminatedTo": {
+                "description": "Name of the winding whose quiet node the shield single-ended termination is connected to",
+                "type": "string"
+            }
+        },
+        "required": ["betweenWindings"]
+    }
+}
+```
+
+### Semantics
+
+- **Placement.** The engine inserts a SHIELDING layer inside each insulation
+  interface between sections of the named pair (insulation | shield |
+  insulation), at materialization time. `interfaces` selects specific
+  occurrences by ordinal so interleaved constructions (P-S-P) can shield only
+  the interfaces that need it; absent, every interface of the pair — including
+  the wrap-around last-to-first interface — is shielded.
+- **Windings are referenced by name**, consistent with `partialWindings`,
+  turns, and bobbin connections. Renames must propagate (reference
+  implementations do).
+- **Sizing.** Foil: `thickness` (a library default applies when absent).
+  Wound: layer thickness is the named wire's outer diameter. Breadth comes
+  from `coverage`, or from `margin` when present (asymmetric margins shift the
+  shield center).
+- **Termination.** A shield terminates at exactly one point (`connection`);
+  the other end floats to avoid a shorted turn around the core. `chassis`
+  terminations model safety-ground shields; `terminatedTo` records the
+  intended quiet node for future capacitance modeling.
+
+## Migration policy
+
+Purely additive: documents without `shielding` are unaffected, and no existing
+field changes meaning. Documents that *use* `shielding` will not validate
+against earlier schema releases (`designRequirements` is a closed object), so
+this rides a MINOR release. Casing of the `shieldingType` enum follows
+RFC 0007.
+
+## Cost
+
+Schema + regenerated bindings (C++, TypeScript, Python), engine
+materialization, and UI. A complete working implementation of exactly this
+shape exists across the stack (schema, MKF layer insertion including
+interleaving and margins, wasm, builder UI, summary rendering) and will be
+submitted as the linked implementation PRs on acceptance.
+
+## Open questions
+
+1. Should the insulation coordinator credit a grounded shield between the pair
+   (the reference implementation keeps full insulation on both sides —
+   conservative w.r.t. IEC 60664 / 61558)?
+2. Is shielding the wrap-around interface by default the right call, or should
+   it be opt-in via `interfaces`?
+3. Overall/outer shields around the whole winding stack (McLyman ch. 17
+   distinguishes them from inter-winding shields) — a future `placement`
+   field, or out of scope?
+4. Should shield grounding state feed insulation-system modeling once both
+   exist?

--- a/proposals/0010-shielding-requirement.md
+++ b/proposals/0010-shielding-requirement.md
@@ -152,6 +152,33 @@ shape exists across the stack (schema, MKF layer insertion including
 interleaving and margins, wasm, builder UI, summary rendering) and will be
 submitted as the linked implementation PRs on acceptance.
 
+## Alternatives considered
+
+- **A one-turn "shield winding" in `functionalDescription` (the established
+  workaround).** A winding gets placement, painting, and loss models for free
+  and needs no schema or engine change — but it corrupts the electrical model
+  (`turnsRatios` and every operating point acquire a phantom entry, isolation
+  sides miscount), and every consumer must special-case a winding that is not
+  electrically a winding. The winding shape also cannot express single-ended
+  termination: `connections` is a start/finish pair and winding paths assume
+  both ends carry load current. A requirements-level variant (folding shields
+  into `numberWindings`) fails the same way, since the winding count drives
+  `turnsRatios` and per-winding excitations. These are the failures the
+  Motivation section describes.
+
+- **Hand-authoring SHIELDING layers in `layersDescription` (what MAS allows
+  today).** Expresses the result but not the intent: the declaration is not
+  portable across tools, cannot participate in requirement-stage workflows,
+  and is destroyed whenever the coil is re-wound after a core, wire, or
+  interleaving change. It remains the low-level representation this
+  requirement materializes into.
+
+- **Extending the `insulation` requirement instead of a first-class array.**
+  A shield is a conductor, not insulation, and it is placed per interface
+  occurrence rather than per winding pair; folding it into the insulation
+  requirement would overload those pair-level semantics and could not express
+  selectively shielded interleaved constructions.
+
 ## Open questions
 
 1. Should the insulation coordinator credit a grounded shield between the pair

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -33,3 +33,4 @@ before any schema or code lands.
 | [0007](0007-enum-casing-convention.md) | Enum value casing convention | Draft | 1.0.0 |
 | [0008](0008-pollution-overvoltage-iec60664.md) | Pollution/overvoltage IEC 60664 alignment | Draft | 1.0.0 |
 | [0009](0009-coordinate-system-cleanup.md) | Coordinate-system cleanup (polar / cylindrical) | **Implemented** | 0.2.0 |
+| [0010](0010-shielding-requirement.md) | Electrostatic shielding requirement | Draft | 1.1.0 |


### PR DESCRIPTION
## Summary

MAS-RFC 0010 (**Status: Draft**): add an optional `shielding` array to `inputs/designRequirements.json`, declaring electrostatic (Faraday) shields between winding pairs. The engine materializes each requirement as SHIELDING-typed layers at the pair's insulation interfaces — shields stay out of `functionalDescription`, so turns ratios, excitations, and isolation sides are untouched.

Per `GOVERNANCE.md` §4 and the `proposals/` workflow, this PR adds the RFC for the 14-day comment period; discussion happens here and material changes update the RFC text.

## Why now

`layer.type` already includes `shielding`, so the coil description can represent the result — but nothing can *request* it. Users currently fake shields as one-turn windings, which corrupts the electrical model.

A complete working implementation of exactly this shape (schema → MKF materialization incl. interleaved P-S-P constructions, foil/wound sizing, margins → wasm → builder UI → summary) already exists and will be submitted as the linked implementation PRs if the RFC is accepted.

## Merge order / dependencies

Proposal document only — no schema or code change in this PR. Independent of my open implementation PRs elsewhere (WebSharedComponents#9/#10/#11/#15, WebFrontend#21–#24, MagneticBuilderApp#3/#4/#5). Enum casing follows RFC 0007.
