### PR TITLE
docs(samples): mock coil samples for winding-interconnection topologies

### DIFF
--- a/samples/magnetic/coil/mocks/mock_basic.json
+++ b/samples/magnetic/coil/mocks/mock_basic.json
@@ -1,0 +1,38 @@
+{
+  "functionalDescription": [
+    {
+      "name": "P",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "1"
+        },
+        {
+          "type": "pin",
+          "pinName": "2"
+        }
+      ]
+    },
+    {
+      "name": "S",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "secondary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "3"
+        },
+        {
+          "type": "pin",
+          "pinName": "4"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/magnetic/coil/mocks/mock_blind_chain.json
+++ b/samples/magnetic/coil/mocks/mock_blind_chain.json
@@ -1,0 +1,72 @@
+{
+  "functionalDescription": [
+    {
+      "name": "P1",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "1"
+        },
+        {
+          "type": "blind",
+          "pinName": "B1"
+        }
+      ]
+    },
+    {
+      "name": "P2",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "blind",
+          "pinName": "B1"
+        },
+        {
+          "type": "blind",
+          "pinName": "B2"
+        }
+      ]
+    },
+    {
+      "name": "P3",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "blind",
+          "pinName": "B2"
+        },
+        {
+          "type": "pin",
+          "pinName": "2"
+        }
+      ]
+    },
+    {
+      "name": "S",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "secondary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "3"
+        },
+        {
+          "type": "pin",
+          "pinName": "4"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/magnetic/coil/mocks/mock_cross_blind.json
+++ b/samples/magnetic/coil/mocks/mock_cross_blind.json
@@ -1,0 +1,38 @@
+{
+  "functionalDescription": [
+    {
+      "name": "P",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "1"
+        },
+        {
+          "type": "blind",
+          "pinName": "J1"
+        }
+      ]
+    },
+    {
+      "name": "S",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "secondary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "blind",
+          "pinName": "J1"
+        },
+        {
+          "type": "pin",
+          "pinName": "2"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/magnetic/coil/mocks/mock_dual_blind_stars.json
+++ b/samples/magnetic/coil/mocks/mock_dual_blind_stars.json
@@ -1,0 +1,123 @@
+{
+  "functionalDescription": [
+    {
+      "name": "P1",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "1"
+        },
+        {
+          "type": "blind",
+          "pinName": "B1"
+        }
+      ]
+    },
+    {
+      "name": "P2",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "2"
+        },
+        {
+          "type": "blind",
+          "pinName": "B1"
+        }
+      ]
+    },
+    {
+      "name": "P3",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "3"
+        },
+        {
+          "type": "blind",
+          "pinName": "B1"
+        }
+      ]
+    },
+    {
+      "name": "S",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "secondary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "S1"
+        },
+        {
+          "type": "pin",
+          "pinName": "S2"
+        }
+      ]
+    },
+    {
+      "name": "T1",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "tertiary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "4"
+        },
+        {
+          "type": "blind",
+          "pinName": "B2"
+        }
+      ]
+    },
+    {
+      "name": "T2",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "tertiary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "5"
+        },
+        {
+          "type": "blind",
+          "pinName": "B2"
+        }
+      ]
+    },
+    {
+      "name": "T3",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "tertiary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "6"
+        },
+        {
+          "type": "blind",
+          "pinName": "B2"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/magnetic/coil/mocks/mock_dual_secondary.json
+++ b/samples/magnetic/coil/mocks/mock_dual_secondary.json
@@ -1,0 +1,55 @@
+{
+  "functionalDescription": [
+    {
+      "name": "P",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "1"
+        },
+        {
+          "type": "pin",
+          "pinName": "2"
+        }
+      ]
+    },
+    {
+      "name": "S1",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "secondary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "3"
+        },
+        {
+          "type": "pin",
+          "pinName": "4"
+        }
+      ]
+    },
+    {
+      "name": "S2",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "tertiary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "5"
+        },
+        {
+          "type": "pin",
+          "pinName": "6"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/magnetic/coil/mocks/mock_primary_two_blinds.json
+++ b/samples/magnetic/coil/mocks/mock_primary_two_blinds.json
@@ -1,0 +1,89 @@
+{
+  "functionalDescription": [
+    {
+      "name": "P1",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "1"
+        },
+        {
+          "type": "blind",
+          "pinName": "B1"
+        }
+      ]
+    },
+    {
+      "name": "P2",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "2"
+        },
+        {
+          "type": "blind",
+          "pinName": "B1"
+        }
+      ]
+    },
+    {
+      "name": "P3",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "3"
+        },
+        {
+          "type": "blind",
+          "pinName": "B2"
+        }
+      ]
+    },
+    {
+      "name": "P4",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "4"
+        },
+        {
+          "type": "blind",
+          "pinName": "B2"
+        }
+      ]
+    },
+    {
+      "name": "S",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "secondary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "S1"
+        },
+        {
+          "type": "pin",
+          "pinName": "S2"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/magnetic/coil/mocks/mock_star_b1.json
+++ b/samples/magnetic/coil/mocks/mock_star_b1.json
@@ -1,0 +1,72 @@
+{
+  "functionalDescription": [
+    {
+      "name": "P1",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "1"
+        },
+        {
+          "type": "blind",
+          "pinName": "B1"
+        }
+      ]
+    },
+    {
+      "name": "P2",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "2"
+        },
+        {
+          "type": "blind",
+          "pinName": "B1"
+        }
+      ]
+    },
+    {
+      "name": "P3",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "3"
+        },
+        {
+          "type": "blind",
+          "pinName": "B1"
+        }
+      ]
+    },
+    {
+      "name": "S",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "secondary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "S1"
+        },
+        {
+          "type": "pin",
+          "pinName": "S2"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/magnetic/coil/mocks/mock_triple_blind_chain.json
+++ b/samples/magnetic/coil/mocks/mock_triple_blind_chain.json
@@ -1,0 +1,89 @@
+{
+  "functionalDescription": [
+    {
+      "name": "P1",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "1"
+        },
+        {
+          "type": "blind",
+          "pinName": "B1"
+        }
+      ]
+    },
+    {
+      "name": "P2",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "blind",
+          "pinName": "B1"
+        },
+        {
+          "type": "blind",
+          "pinName": "B2"
+        }
+      ]
+    },
+    {
+      "name": "P3",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "blind",
+          "pinName": "B2"
+        },
+        {
+          "type": "blind",
+          "pinName": "B3"
+        }
+      ]
+    },
+    {
+      "name": "P4",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "primary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "blind",
+          "pinName": "B3"
+        },
+        {
+          "type": "pin",
+          "pinName": "2"
+        }
+      ]
+    },
+    {
+      "name": "S",
+      "numberTurns": 10,
+      "numberParallels": 1,
+      "isolationSide": "secondary",
+      "wire": "Dummy",
+      "connections": [
+        {
+          "type": "pin",
+          "pinName": "3"
+        },
+        {
+          "type": "pin",
+          "pinName": "4"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Eight coil `functionalDescription` samples under `samples/magnetic/coil/mocks/`: reference winding-interconnection topologies — a basic two-winding case, dual secondaries, star points, blind chains (series joints not brought out to a terminal), and cross-group joins.

## Why

The `samples/` tree covers requirements and single magnetics but has no coverage of multi-winding **interconnection** topologies. These are the reference cases used to develop and test the coil-schematic generator (OpenMagnetics/WebSharedComponents#11), and they give any MAS consumer concrete documents for the tricky connection shapes.

The topology is the payload: `numberTurns` / `numberParallels` / `wire` carry placeholder values so every sample is a schema-valid winding list.

## Merge order / dependencies

The blind-junction samples use `"type": "blind"`, so this PR validates only once **Power-Supply-Manufacturers-Association/PEAS#1** (adds `blind` to the `connectionType` enum) is merged — merge that first. No other dependencies; purely additive sample data, no schema changes.
