### PR TITLE
fix(schemas): title the coil 'connection' definition for stable codegen

### DIFF
--- a/schemas/magnetic/coil.json
+++ b/schemas/magnetic/coil.json
@@ -650,6 +650,7 @@
         },
         "connection": {
             "description": "Connection of a wire to a terminal.",
+            "title": "connectionElement",
             "type": "object",
             "properties": {
                 "type": {


### PR DESCRIPTION
## Summary

One line: add `"title": "connectionElement"` to the `connection` definition in `schemas/magnetic/coil.json`.

## Why

quicktype names generated classes from a definition's **title**, falling back to reference-site heuristics when untitled. `connection` is untitled, so the generated class name (`ConnectionElement` in `MAS.hpp` / `MAS.ts`) is an accident of its single `$ref` site — **the moment a second `$ref` points at this definition, quicktype renames the class to `Connection`**, silently breaking every consumer of the generated code (MKF, the web apps' typed MAS bindings).

Found the hard way while prototyping MAS-RFC 0010 (#23): `ShieldingRequirement.connection` adds exactly such a second `$ref`, and the generated class flipped names until the definition was titled. Titling it now makes codegen order-independent before any new reference lands.

## Compatibility

Annotation-only — `title` carries no validation semantics. Regenerated code is identical today; the title simply pins the name generation already produces.
